### PR TITLE
feat: add Brave Search API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@
 # Get your key at: https://tavily.com/
 # TAVILY_API_KEY=your_tavily_api_key
 
+# Brave Search API
+# Get your key at: https://brave.com/search/api/
+# BRAVE_SEARCH_API_KEY=your_brave_search_api_key
+
 # =============================================================================
 # Image Search API Keys
 # =============================================================================

--- a/pai_agent_sdk/context/agent.py
+++ b/pai_agent_sdk/context/agent.py
@@ -218,6 +218,9 @@ class ToolSettings(BaseSettings):
     tavily_api_key: str | None = None
     """Tavily API key for web search."""
 
+    brave_search_api_key: str | None = None
+    """Brave Search API key."""
+
     # Image search API keys
     pixabay_api_key: str | None = None
     """Pixabay API key for stock image search."""
@@ -457,6 +460,9 @@ class ToolConfig(BaseModel):
 
     tavily_api_key: str | None = Field(default_factory=lambda: _get_tool_settings().tavily_api_key)
     """Tavily API key for web search."""
+
+    brave_search_api_key: str | None = Field(default_factory=lambda: _get_tool_settings().brave_search_api_key)
+    """Brave Search API key."""
 
     # Image search API keys
     pixabay_api_key: str | None = Field(default_factory=lambda: _get_tool_settings().pixabay_api_key)


### PR DESCRIPTION
Add Brave Search as an alternative search provider with priority: Google > Brave > Tavily

- Add BRAVE_SEARCH_API_KEY to .env.example
- Add brave_search_api_key to ToolSettings and ToolConfig
- Implement _search_brave() method in SearchTool
- Update is_available() to check for Brave API key