### PR TITLE
feat(image): auto-split large images before model requests

### DIFF
--- a/pai_agent_sdk/context/agent.py
+++ b/pai_agent_sdk/context/agent.py
@@ -69,7 +69,7 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 from xml.dom.minidom import parseString
@@ -170,7 +170,7 @@ Example::
 # =============================================================================
 
 
-class ModelCapability(str, Enum):
+class ModelCapability(StrEnum):
     """Model capabilities that can be used to describe what a model supports."""
 
     vision = "vision"
@@ -555,6 +555,15 @@ class ModelConfig(BaseModel):
 
     support_gif: bool = True
     """Whether the model supports GIF images. If False, GIF images will be filtered out."""
+
+    split_large_images: bool = True
+    """Whether to split oversized binary images before sending to model."""
+
+    image_split_max_height: int = 4096
+    """Maximum height (in pixels) for each image segment when splitting large images."""
+
+    image_split_overlap: int = 50
+    """Overlap (in pixels) between adjacent image segments when splitting."""
 
     capabilities: set[ModelCapability] = Field(default_factory=set)
     """Set of capabilities supported by the model."""
@@ -1302,7 +1311,7 @@ class AgentContext(BaseModel):
         from pai_agent_sdk.filters.bus_message import inject_bus_messages
         from pai_agent_sdk.filters.capability import filter_by_capability
         from pai_agent_sdk.filters.handoff import process_handoff_message
-        from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images
+        from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images, split_large_images
         from pai_agent_sdk.filters.runtime_instructions import inject_runtime_instructions
         from pai_agent_sdk.filters.tool_args import fix_truncated_tool_args
 
@@ -1312,6 +1321,7 @@ class AgentContext(BaseModel):
 
         return [
             # handle_model_switch, # Disabled as response.model_name is not the same as ctx.model.model_name
+            split_large_images,
             drop_extra_images,
             drop_gif_images,
             drop_extra_videos,

--- a/pai_agent_sdk/context/agent.py
+++ b/pai_agent_sdk/context/agent.py
@@ -1311,7 +1311,12 @@ class AgentContext(BaseModel):
         from pai_agent_sdk.filters.bus_message import inject_bus_messages
         from pai_agent_sdk.filters.capability import filter_by_capability
         from pai_agent_sdk.filters.handoff import process_handoff_message
-        from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images, split_large_images
+        from pai_agent_sdk.filters.image import (
+            drop_extra_images,
+            drop_extra_videos,
+            drop_gif_images,
+            split_large_images,
+        )
         from pai_agent_sdk.filters.runtime_instructions import inject_runtime_instructions
         from pai_agent_sdk.filters.tool_args import fix_truncated_tool_args
 

--- a/pai_agent_sdk/context/tasks.py
+++ b/pai_agent_sdk/context/tasks.py
@@ -7,13 +7,13 @@ multi-step work within agent sessions.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 
-class TaskStatus(str, Enum):
+class TaskStatus(StrEnum):
     """Task execution status."""
 
     PENDING = "pending"

--- a/pai_agent_sdk/filters/__init__.py
+++ b/pai_agent_sdk/filters/__init__.py
@@ -6,7 +6,7 @@ This module provides history processors for pydantic-ai agents.
 from pai_agent_sdk.filters.auto_load_files import process_auto_load_files
 from pai_agent_sdk.filters.environment_instructions import create_environment_instructions_filter
 from pai_agent_sdk.filters.handoff import process_handoff_message
-from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images
+from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images, split_large_images
 from pai_agent_sdk.filters.media_upload import create_media_upload_filter
 from pai_agent_sdk.filters.system_prompt import create_system_prompt_filter
 from pai_agent_sdk.filters.tool_args import fix_truncated_tool_args
@@ -21,4 +21,5 @@ __all__ = [
     "fix_truncated_tool_args",
     "process_auto_load_files",
     "process_handoff_message",
+    "split_large_images",
 ]

--- a/pai_agent_sdk/filters/image.py
+++ b/pai_agent_sdk/filters/image.py
@@ -34,6 +34,7 @@ Example::
 
 import io
 from collections.abc import Sequence
+from typing import cast
 
 from PIL import Image
 from pydantic_ai.messages import (
@@ -49,6 +50,7 @@ from pydantic_ai.tools import RunContext
 
 from pai_agent_sdk._logger import logger
 from pai_agent_sdk.context import AgentContext
+from pai_agent_sdk.utils import ImageMediaType, split_image_data
 
 
 def _is_image_content(item: UserContent) -> bool:
@@ -80,6 +82,108 @@ def _validate_image(content: BinaryContent) -> bool:
         return True
     except Exception:
         return False
+
+
+async def _split_image_content_list(
+    content_list: list[UserContent],
+    *,
+    max_height: int,
+    overlap: int,
+) -> tuple[list[UserContent], bool]:
+    """Split oversized binary images in a content list.
+
+    Returns:
+        A tuple of (processed_content, modified).
+    """
+    new_content: list[UserContent] = []
+    modified = False
+
+    for item in content_list:
+        if not isinstance(item, BinaryContent) or not item.media_type.startswith("image/"):
+            new_content.append(item)
+            continue
+
+        media_type = cast(ImageMediaType, item.media_type)
+
+        try:
+            segments = await split_image_data(
+                image_bytes=item.data,
+                max_height=max_height,
+                overlap=overlap,
+                media_type=media_type,
+            )
+        except Exception:
+            logger.exception("Failed to split image; keeping original binary content")
+            new_content.append(item)
+            continue
+
+        if len(segments) <= 1:
+            new_content.append(item)
+            continue
+
+        logger.info(
+            "Split large image into %d segments (max_height=%d, overlap=%d)",
+            len(segments),
+            max_height,
+            overlap,
+        )
+        new_content.extend(segments)
+        modified = True
+
+    return new_content, modified
+
+
+async def split_large_images(
+    ctx: RunContext[AgentContext],
+    message_history: list[ModelMessage],
+) -> list[ModelMessage]:
+    """Split oversized binary image content in message history.
+
+    This is a pydantic-ai history_processor that:
+    1. Splits BinaryContent images whose height exceeds configured threshold
+    2. Preserves image order by replacing one image with multiple segments
+    3. Leaves non-image content unchanged
+
+    Behavior is controlled by ModelConfig:
+    - split_large_images: master enable/disable switch
+    - image_split_max_height: max height per segment
+    - image_split_overlap: vertical overlap between segments
+
+    Args:
+        ctx: Runtime context containing AgentContext with model configuration.
+        message_history: List of messages to process.
+
+    Returns:
+        The modified message history with oversized images split into segments.
+    """
+    model_cfg = ctx.deps.model_cfg
+
+    if model_cfg and not model_cfg.split_large_images:
+        return message_history
+
+    max_height = model_cfg.image_split_max_height if model_cfg else 4096
+    overlap = model_cfg.image_split_overlap if model_cfg else 50
+
+    for message in message_history:
+        if not isinstance(message, ModelRequest):
+            continue
+
+        for part in message.parts:
+            if not isinstance(part, UserPromptPart) or isinstance(part.content, str):
+                continue
+
+            content_list: list[UserContent] = (
+                list(part.content) if isinstance(part.content, Sequence) else [part.content]
+            )
+            new_content, modified = await _split_image_content_list(
+                content_list,
+                max_height=max_height,
+                overlap=overlap,
+            )
+            if modified:
+                part.content = new_content
+
+    return message_history
 
 
 def drop_extra_images(

--- a/pai_agent_sdk/presets.py
+++ b/pai_agent_sdk/presets.py
@@ -29,7 +29,7 @@ Usage::
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 from pai_agent_sdk.context import ModelCapability
@@ -72,7 +72,7 @@ def build_anthropic_betas(
 # =============================================================================
 
 
-class ModelSettingsPreset(str, Enum):
+class ModelSettingsPreset(StrEnum):
     """Available ModelSettings presets."""
 
     # Anthropic standard presets (no beta headers)
@@ -633,7 +633,7 @@ def list_presets() -> list[str]:
 INHERIT = "inherit"
 
 
-class ModelConfigPreset(str, Enum):
+class ModelConfigPreset(StrEnum):
     """Available ModelConfig presets for context management."""
 
     # Anthropic models
@@ -656,6 +656,9 @@ _MODEL_CFG_REGISTRY: dict[str, dict[str, Any]] = {
         "max_images": 20,
         "max_videos": 0,  # Claude doesn't support video
         "support_gif": True,
+        "split_large_images": True,
+        "image_split_max_height": 4096,
+        "image_split_overlap": 50,
         "capabilities": {ModelCapability.vision, ModelCapability.document_understanding},
     },
     ModelConfigPreset.CLAUDE_1M.value: {
@@ -663,6 +666,9 @@ _MODEL_CFG_REGISTRY: dict[str, dict[str, Any]] = {
         "max_images": 20,
         "max_videos": 0,  # Claude doesn't support video
         "support_gif": True,
+        "split_large_images": True,
+        "image_split_max_height": 4096,
+        "image_split_overlap": 50,
         "capabilities": {ModelCapability.vision, ModelCapability.document_understanding},
     },
     # OpenAI GPT-5 series (vision, no video support)
@@ -671,6 +677,9 @@ _MODEL_CFG_REGISTRY: dict[str, dict[str, Any]] = {
         "max_images": 20,
         "max_videos": 0,  # GPT doesn't support video
         "support_gif": False,
+        "split_large_images": True,
+        "image_split_max_height": 4096,
+        "image_split_overlap": 50,
         "capabilities": {ModelCapability.vision},
     },
     # Gemini models (vision + video support)
@@ -679,6 +688,9 @@ _MODEL_CFG_REGISTRY: dict[str, dict[str, Any]] = {
         "max_images": 20,
         "max_videos": 1,  # Gemini supports video
         "support_gif": True,
+        "split_large_images": True,
+        "image_split_max_height": 4096,
+        "image_split_overlap": 50,
         "capabilities": {
             ModelCapability.vision,
             ModelCapability.video_understanding,
@@ -690,6 +702,9 @@ _MODEL_CFG_REGISTRY: dict[str, dict[str, Any]] = {
         "max_images": 20,
         "max_videos": 1,  # Gemini supports video
         "support_gif": True,
+        "split_large_images": True,
+        "image_split_max_height": 4096,
+        "image_split_overlap": 50,
         "capabilities": {
             ModelCapability.vision,
             ModelCapability.video_understanding,

--- a/pai_agent_sdk/toolsets/core/content/_url_helper.py
+++ b/pai_agent_sdk/toolsets/core/content/_url_helper.py
@@ -4,13 +4,13 @@ This module provides helper functions to validate URLs and detect content types
 for the LoadMediaUrlTool.
 """
 
-from enum import Enum
+from enum import StrEnum
 from urllib.parse import urlparse
 
 import httpx
 
 
-class ContentCategory(str, Enum):
+class ContentCategory(StrEnum):
     """Categories of content that can be loaded from a URL."""
 
     image = "image"

--- a/paintress_cli/paintress_cli/app/state.py
+++ b/paintress_cli/paintress_cli/app/state.py
@@ -6,10 +6,10 @@ Provides explicit state machine for TUI application state.
 from __future__ import annotations
 
 from collections.abc import Callable
-from enum import Enum, auto
+from enum import Enum, StrEnum, auto
 
 
-class TUIMode(str, Enum):
+class TUIMode(StrEnum):
     """Agent operating mode."""
 
     ACT = "act"

--- a/paintress_cli/paintress_cli/app/tui.py
+++ b/paintress_cli/paintress_cli/app/tui.py
@@ -26,7 +26,7 @@ import sys
 import time
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, cast
@@ -107,7 +107,7 @@ and adjust your work accordingly while continuing toward the goal.
 
 
 # TUIState kept for backward compatibility (used in tests and status bar)
-class TUIState(str, Enum):
+class TUIState(StrEnum):
     """TUI application state (legacy, use TUIStateMachine for new code)."""
 
     IDLE = "idle"

--- a/paintress_cli/paintress_cli/rendering/types.py
+++ b/paintress_cli/paintress_cli/rendering/types.py
@@ -5,14 +5,14 @@ Contains enums and data classes used across the rendering layer.
 
 from __future__ import annotations
 
-import enum
 import time
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
 
 
-class ToolCallState(str, enum.Enum):
+class ToolCallState(StrEnum):
     """Tool call execution state."""
 
     CALLING = "calling"
@@ -20,7 +20,7 @@ class ToolCallState(str, enum.Enum):
     RENDERED = "rendered"
 
 
-class RenderDirective(str, enum.Enum):
+class RenderDirective(StrEnum):
     """Render directive for display updates."""
 
     CALLING = "calling"

--- a/tests/filters/test_image.py
+++ b/tests/filters/test_image.py
@@ -17,7 +17,7 @@ from pydantic_ai.messages import (
 
 from pai_agent_sdk.context import AgentContext, ModelConfig
 from pai_agent_sdk.environment.local import LocalEnvironment
-from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images
+from pai_agent_sdk.filters.image import drop_extra_images, drop_extra_videos, drop_gif_images, split_large_images
 
 
 def _create_valid_image_bytes() -> bytes:
@@ -31,6 +31,119 @@ def _create_valid_image_bytes() -> bytes:
 def _create_broken_image_bytes() -> bytes:
     """Create broken image bytes."""
     return b"not a valid image"
+
+
+def _create_valid_tall_image_bytes(height: int = 5000, width: int = 120) -> bytes:
+    """Create a valid tall PNG image bytes."""
+    img = Image.new("RGB", (width, height), color="blue")
+    buffer = BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+# Tests for split_large_images
+
+
+async def test_split_large_images_splits_tall_binary_image(tmp_path: Path) -> None:
+    """Should split tall binary image into multiple segments."""
+    async with LocalEnvironment(
+        allowed_paths=[tmp_path],
+        default_path=tmp_path,
+        tmp_base_dir=tmp_path,
+    ) as env:
+        async with AgentContext(
+            env=env,
+            model_cfg=ModelConfig(
+                split_large_images=True,
+                image_split_max_height=1000,
+                image_split_overlap=100,
+            ),
+        ) as ctx:
+            mock_ctx = MagicMock()
+            mock_ctx.deps = ctx
+
+            tall_image = BinaryContent(data=_create_valid_tall_image_bytes(height=2600), media_type="image/png")
+            request = ModelRequest(parts=[UserPromptPart(content=[tall_image])])
+            history = [request]
+
+            result = await split_large_images(mock_ctx, history)
+
+            assert result == history
+            content = request.parts[0].content  # type: ignore[union-attr]
+            assert isinstance(content, list)
+            assert len(content) == 3
+            assert all(isinstance(item, BinaryContent) for item in content)
+            assert all(item.media_type == "image/png" for item in content)
+
+
+async def test_split_large_images_disabled_by_config(tmp_path: Path) -> None:
+    """Should keep image unchanged when split_large_images is disabled."""
+    async with LocalEnvironment(
+        allowed_paths=[tmp_path],
+        default_path=tmp_path,
+        tmp_base_dir=tmp_path,
+    ) as env:
+        async with AgentContext(
+            env=env,
+            model_cfg=ModelConfig(
+                split_large_images=False,
+                image_split_max_height=1000,
+                image_split_overlap=100,
+            ),
+        ) as ctx:
+            mock_ctx = MagicMock()
+            mock_ctx.deps = ctx
+
+            tall_image = BinaryContent(data=_create_valid_tall_image_bytes(height=2600), media_type="image/png")
+            request = ModelRequest(parts=[UserPromptPart(content=[tall_image])])
+            history = [request]
+
+            await split_large_images(mock_ctx, history)
+
+            content = request.parts[0].content  # type: ignore[union-attr]
+            assert isinstance(content, list)
+            assert len(content) == 1
+            assert isinstance(content[0], BinaryContent)
+            assert content[0].data == tall_image.data
+
+
+async def test_split_large_images_keeps_non_image_content(tmp_path: Path) -> None:
+    """Should only split binary image content and keep others unchanged."""
+    async with LocalEnvironment(
+        allowed_paths=[tmp_path],
+        default_path=tmp_path,
+        tmp_base_dir=tmp_path,
+    ) as env:
+        async with AgentContext(
+            env=env,
+            model_cfg=ModelConfig(
+                split_large_images=True,
+                image_split_max_height=1000,
+                image_split_overlap=100,
+            ),
+        ) as ctx:
+            mock_ctx = MagicMock()
+            mock_ctx.deps = ctx
+
+            text = "hello"
+            image_url = ImageUrl(url="https://example.com/image.png")
+            tall_image = BinaryContent(data=_create_valid_tall_image_bytes(height=2600), media_type="image/png")
+            video = VideoUrl(url="https://example.com/video.mp4")
+            request = ModelRequest(parts=[UserPromptPart(content=[text, image_url, tall_image, video])])
+            history = [request]
+
+            await split_large_images(mock_ctx, history)
+
+            content = request.parts[0].content  # type: ignore[union-attr]
+            assert isinstance(content, list)
+            # text + image_url + 3 image segments + video = 6
+            assert len(content) == 6
+            assert content[0] == text
+            assert isinstance(content[1], ImageUrl)
+            assert isinstance(content[2], BinaryContent)
+            assert isinstance(content[3], BinaryContent)
+            assert isinstance(content[4], BinaryContent)
+            assert isinstance(content[5], VideoUrl)
 
 
 # Tests for drop_extra_images

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from pai_agent_sdk.context import AgentContext, TaskStatus
+from pai_agent_sdk.context import AgentContext, ModelConfig, TaskStatus
 from pai_agent_sdk.environment.local import LocalEnvironment
 
 
@@ -34,6 +34,22 @@ async def test_agent_context_no_parent_by_default(env: LocalEnvironment) -> None
     """Should have no parent by default."""
     ctx = AgentContext(env=env)
     assert ctx.parent_run_id is None
+
+
+async def test_model_config_image_split_defaults() -> None:
+    """Should provide sensible defaults for image splitting."""
+    cfg = ModelConfig()
+    assert cfg.split_large_images is True
+    assert cfg.image_split_max_height == 4096
+    assert cfg.image_split_overlap == 50
+
+
+async def test_model_config_image_split_custom_values() -> None:
+    """Should allow overriding image splitting config values."""
+    cfg = ModelConfig(split_large_images=False, image_split_max_height=2048, image_split_overlap=64)
+    assert cfg.split_large_images is False
+    assert cfg.image_split_max_height == 2048
+    assert cfg.image_split_overlap == 64
 
 
 async def test_agent_context_elapsed_time_before_start(env: LocalEnvironment) -> None:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -238,11 +238,17 @@ def test_model_cfg_presets_structure() -> None:
     assert cfg["context_window"] == 200_000
     assert cfg["max_videos"] == 0  # Claude doesn't support video
     assert "max_images" in cfg
+    assert "split_large_images" in cfg
+    assert "image_split_max_height" in cfg
+    assert "image_split_overlap" in cfg
     assert "capabilities" in cfg
 
     cfg_1m = get_model_cfg("claude_1m")
     assert cfg_1m["context_window"] == 1_000_000
     assert cfg_1m["max_videos"] == 0  # Claude doesn't support video
+    assert cfg_1m["split_large_images"] is True
+    assert cfg_1m["image_split_max_height"] == 4096
+    assert cfg_1m["image_split_overlap"] == 50
 
 
 def test_model_cfg_capabilities() -> None:


### PR DESCRIPTION
- add split_large_images history processor to split oversized image binary content
- wire image splitting behavior into preset/history processing flow
- extend tests for image split behavior and related context/preset integration