### PR TITLE
feat(cli): add git worktree mode and session management

### DIFF
--- a/paintress_cli/paintress_cli/app/tui.py
+++ b/paintress_cli/paintress_cli/app/tui.py
@@ -22,10 +22,13 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import shutil
 import sys
 import time
+import uuid
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from types import TracebackType
@@ -136,6 +139,7 @@ class TUIApp:
     config: PaintressConfig
     config_manager: ConfigManager
     verbose: bool = False
+    working_dir: Path = field(default_factory=Path.cwd)
 
     # Runtime state
     _mode: TUIMode = field(default=TUIMode.ACT, init=False)
@@ -161,6 +165,9 @@ class TUIApp:
     _total_line_count: int = field(default=0, init=False)  # Cached line count
     _renderer: RichRenderer = field(default_factory=RichRenderer, init=False)
     _event_renderer: EventRenderer = field(default_factory=EventRenderer, init=False)
+
+    # Session
+    _session_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12], init=False)
 
     # Agent execution
     _agent_task: asyncio.Task[None] | None = field(default=None, init=False)
@@ -264,7 +271,7 @@ class TUIApp:
             config=self.config,
             mcp_config=mcp_config,
             browser_manager=self._browser,
-            working_dir=Path.cwd(),
+            working_dir=self.working_dir,
         )
         await self._exit_stack.enter_async_context(self._runtime)
 
@@ -718,7 +725,7 @@ class TUIApp:
         user_rules = None
 
         # Load AGENTS.md from working directory
-        agents_path = Path.cwd() / "AGENTS.md"
+        agents_path = self.working_dir / "AGENTS.md"
         if agents_path.exists() and agents_path.is_file():
             try:
                 content = agents_path.read_text(encoding="utf-8")
@@ -1604,16 +1611,17 @@ class TUIApp:
             case "/dump":
                 self._append_user_input(command)
                 self._dump_history(args.strip() if args else None)
+            case "/session":
+                self._append_user_input(command)
+                if not args.strip():
+                    self._list_sessions()
+                else:
+                    self._load_session(args.strip())
             case "/load":
                 self._append_user_input(command)
                 if not args.strip():
-                    # Load from auto-save directory
-                    auto_save_dir = self.config_manager.get_auto_save_dir()
-                    if auto_save_dir.exists():
-                        self._load_history(str(auto_save_dir))
-                    else:
-                        self._append_system_output("No auto-saved session found for this project")
-                        self._append_system_output(f"Expected: {auto_save_dir}")
+                    self._append_system_output("Usage: /load <folder>")
+                    self._append_system_output("To restore a session by ID, use /session <id>")
                 else:
                     self._load_history(args.strip())
             case "/exit":
@@ -1670,7 +1678,7 @@ class TUIApp:
                 command_str,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=Path.cwd(),
+                cwd=self.working_dir,
                 env=os.environ.copy(),
             )
 
@@ -1730,6 +1738,7 @@ class TUIApp:
         sys_table.add_row("/help", "Show this help")
         sys_table.add_row("/clear", "Clear output and history")
         sys_table.add_row("/cost", "Show cost summary")
+        sys_table.add_row("/session [id]", "List sessions or restore by ID")
         sys_table.add_row("/dump [folder]", "Export session to folder")
         sys_table.add_row("/load <folder>", "Load session from folder")
         sys_table.add_row("/act", "Switch to ACT mode")
@@ -1903,18 +1912,22 @@ class TUIApp:
             self._append_system_output(f"Error loading session: {e}")
 
     def _auto_save_history(self) -> None:
-        """Auto-save session to project-specific directory.
+        """Auto-save session to session-specific directory.
 
-        Saves message history and context state to:
-        ~/.config/youware-labs/paintress-cli/message_history/{project_hash}/
+        Saves message history, context state, and metadata to:
+        ~/.config/youware-labs/paintress-cli/sessions/{session_id}/
 
         This is called automatically after each agent run completes.
+        Also prunes old sessions beyond the retention limit.
         """
         if not self._message_history:
             return
 
-        save_dir = self.config_manager.get_auto_save_dir()
+        sessions_dir = self.config_manager.get_sessions_dir()
+        save_dir = sessions_dir / self._session_id
         save_dir.mkdir(parents=True, exist_ok=True)
+
+        now = datetime.now(UTC).isoformat()
 
         # Save message history
         history_file = save_dir / "message_history.json"
@@ -1925,7 +1938,168 @@ class TUIApp:
         state = self.runtime.ctx.export_state()
         state_file.write_text(state.model_dump_json(indent=2))
 
+        # Save/update metadata
+        metadata_file = save_dir / "metadata.json"
+        if metadata_file.exists():
+            metadata = json.loads(metadata_file.read_text())
+            metadata["updated_at"] = now
+        else:
+            metadata = {
+                "session_id": self._session_id,
+                "working_dir": str(self.working_dir),
+                "created_at": now,
+                "updated_at": now,
+            }
+        metadata_file.write_text(json.dumps(metadata, indent=2))
+
         logger.debug(f"Auto-saved session to {save_dir}")
+
+        # Prune old sessions
+        self._prune_sessions(sessions_dir)
+
+    @property
+    def session_id(self) -> str:
+        """Get the current session ID."""
+        return self._session_id
+
+    @property
+    def has_session_data(self) -> bool:
+        """Check if this session has any saved data."""
+        sessions_dir = self.config_manager.get_sessions_dir()
+        return (sessions_dir / self._session_id / "message_history.json").exists()
+
+    def _prune_sessions(self, sessions_dir: Path, max_sessions: int = 100) -> None:
+        """Remove old sessions beyond the retention limit.
+
+        Keeps the most recent `max_sessions` sessions, deleting the rest.
+        Sessions are sorted by updated_at from metadata.json, falling back
+        to directory mtime.
+
+        Args:
+            sessions_dir: Path to config_dir/sessions/
+            max_sessions: Maximum number of sessions to retain.
+        """
+        if not sessions_dir.exists():
+            return
+
+        session_dirs = [d for d in sessions_dir.iterdir() if d.is_dir()]
+        if len(session_dirs) <= max_sessions:
+            return
+
+        def _get_session_time(d: Path) -> str:
+            metadata_file = d / "metadata.json"
+            if metadata_file.exists():
+                try:
+                    metadata = json.loads(metadata_file.read_text())
+                    return metadata.get("updated_at", "")
+                except (json.JSONDecodeError, OSError):
+                    pass
+            # Fallback to directory mtime
+            return datetime.fromtimestamp(d.stat().st_mtime, tz=UTC).isoformat()
+
+        # Sort by time ascending (oldest first)
+        session_dirs.sort(key=_get_session_time)
+
+        # Remove oldest sessions
+        to_remove = session_dirs[: len(session_dirs) - max_sessions]
+        for d in to_remove:
+            try:
+                shutil.rmtree(d)
+                logger.debug(f"Pruned old session: {d.name}")
+            except OSError as e:
+                logger.warning(f"Failed to prune session {d.name}: {e}")
+
+    def _list_sessions(self, max_display: int = 20) -> None:
+        """List recent sessions.
+
+        Shows session ID, timestamp, and working directory.
+
+        Args:
+            max_display: Maximum number of sessions to show.
+        """
+        from rich.table import Table
+
+        sessions_dir = self.config_manager.get_sessions_dir()
+        if not sessions_dir.exists():
+            self._append_system_output("No sessions found.")
+            return
+
+        session_dirs = [d for d in sessions_dir.iterdir() if d.is_dir()]
+        if not session_dirs:
+            self._append_system_output("No sessions found.")
+            return
+
+        # Collect session info
+        sessions: list[dict[str, str]] = []
+        for d in session_dirs:
+            metadata_file = d / "metadata.json"
+            if metadata_file.exists():
+                try:
+                    metadata = json.loads(metadata_file.read_text())
+                    sessions.append({
+                        "id": d.name,
+                        "updated_at": metadata.get("updated_at", "unknown"),
+                        "working_dir": metadata.get("working_dir", "unknown"),
+                    })
+                except (json.JSONDecodeError, OSError):
+                    sessions.append({"id": d.name, "updated_at": "unknown", "working_dir": "unknown"})
+            else:
+                sessions.append({"id": d.name, "updated_at": "unknown", "working_dir": "unknown"})
+
+        # Sort by updated_at descending (newest first)
+        sessions.sort(key=lambda s: s["updated_at"], reverse=True)
+
+        # Mark current session
+        current_id = self._session_id
+
+        table = Table(show_header=True, box=None, padding=(0, 2))
+        table.add_column("Session ID", style="cyan")
+        table.add_column("Updated", style="dim")
+        table.add_column("Working Dir", style="dim")
+
+        for s in sessions[:max_display]:
+            sid = s["id"]
+            marker = f"{sid} *" if sid == current_id else sid
+            # Shorten timestamp for display
+            updated = s["updated_at"][:19].replace("T", " ") if s["updated_at"] != "unknown" else "unknown"
+            table.add_row(marker, updated, s["working_dir"])
+
+        self._append_system_output(
+            f"Sessions ({len(sessions)} total, showing latest {min(len(sessions), max_display)}):"
+        )
+        self._append_output(self._renderer.render(table).rstrip())
+        self._append_system_output("Use /session <id> to restore. (* = current session)")
+
+    def _load_session(self, session_id: str) -> None:
+        """Load a session by ID (supports prefix matching).
+
+        Args:
+            session_id: Full or prefix of session ID.
+        """
+        sessions_dir = self.config_manager.get_sessions_dir()
+        if not sessions_dir.exists():
+            self._append_system_output("No sessions found.")
+            return
+
+        # Exact match first
+        target = sessions_dir / session_id
+        if target.is_dir():
+            self._load_history(str(target))
+            self._session_id = session_id
+            return
+
+        # Prefix match
+        matches = [d for d in sessions_dir.iterdir() if d.is_dir() and d.name.startswith(session_id)]
+        if len(matches) == 1:
+            self._load_history(str(matches[0]))
+            self._session_id = matches[0].name
+            return
+        elif len(matches) > 1:
+            self._append_system_output(f"Ambiguous session ID '{session_id}'. Matches:")
+            for m in sorted(matches, key=lambda d: d.name):
+                self._append_system_output(f"  {m.name}")
+        else:
+            self._append_system_output(f"Session not found: {session_id}")
 
     def _append_system_output(self, text: str) -> None:
         """Append system message to output."""
@@ -1949,12 +2123,8 @@ class TUIApp:
         self._append_output("")  # blank line before help
         self._show_help()
 
-        # Hint about auto-saved session if available
-        auto_save_dir = self.config_manager.get_auto_save_dir()
-        if (auto_save_dir / "message_history.json").exists():
-            self._append_output("")
-            hint = Text("Previous session found. Use /load to restore.", style="dim")
-            self._append_output(self._renderer.render(hint).rstrip())
+        # Show session ID
+        self._append_output(f"Session: {self._session_id}")
 
         # Create scrollable FormattedTextControl with mouse support
         tui_ref = self

--- a/paintress_cli/paintress_cli/cli.py
+++ b/paintress_cli/paintress_cli/cli.py
@@ -7,17 +7,21 @@ Most interactions happen inside the TUI via slash commands.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import os
 import re
 import shutil
+import subprocess
 import sys
+from datetime import UTC, datetime
 from importlib import resources
 from pathlib import Path
 
 import click
 
 from paintress_cli import __version__  # pyright: ignore[reportAttributeAccessIssue]
-from paintress_cli.config import ConfigManager, PaintressConfig
+from paintress_cli.config import ConfigManager, WorktreeMetadata, PaintressConfig
 from paintress_cli.logging import LOG_FILE_NAME, configure_logging, get_logger
 
 logger = get_logger(__name__)
@@ -443,22 +447,123 @@ def ensure_builtin_assets(config_manager: ConfigManager) -> None:
 
 
 # =============================================================================
+# Git Worktree Support
+# =============================================================================
+
+
+def _get_git_root() -> Path | None:
+    """Get the root directory of the current git repository.
+
+    Returns:
+        Path to git root, or None if not in a git repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _project_hash(git_root: Path) -> str:
+    """Generate stable hash from git root path.
+
+    Returns:
+        A 12-character hex string derived from SHA256 of the absolute path.
+    """
+    path_str = str(git_root.resolve())
+    return hashlib.sha256(path_str.encode()).hexdigest()[:12]
+
+
+def _create_worktree(branch_name: str | None) -> tuple[Path, str, bool]:
+    """Create or resume a git worktree for isolated agent work.
+
+    If a worktree with the given branch name already exists, it will be
+    reused (resumed) instead of creating a new one.
+
+    Args:
+        branch_name: Branch name to create. If None, auto-generates one.
+
+    Returns:
+        Tuple of (worktree_path, branch_name, is_resume).
+
+    Raises:
+        click.ClickException: If not in a git repo or worktree creation fails.
+    """
+    git_root = _get_git_root()
+    if git_root is None:
+        raise click.ClickException("--worktree requires a git repository, but none was found.")
+
+    # Auto-generate branch name if not provided
+    if branch_name is None:
+        timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+        branch_name = f"paintress/{timestamp}"
+
+    # Create worktree directory under config_dir/worktrees/{project_hash}/{branch}
+    proj_hash = _project_hash(git_root)
+    worktrees_dir = ConfigManager.DEFAULT_CONFIG_DIR / "worktrees" / proj_hash
+    worktrees_dir.mkdir(parents=True, exist_ok=True)
+    worktree_dir = worktrees_dir / branch_name.replace("/", "-")
+
+    # Write metadata for discoverability
+    metadata_file = worktrees_dir / "metadata.json"
+    if not metadata_file.exists():
+        metadata: WorktreeMetadata = {
+            "git_root": str(git_root.resolve()),
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        metadata_file.write_text(json.dumps(metadata, indent=2))
+
+    # Resume if worktree already exists
+    if worktree_dir.exists():
+        return worktree_dir, branch_name, True
+
+    try:
+        subprocess.run(  # noqa: S603
+            ["git", "worktree", "add", str(worktree_dir), "-b", branch_name],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(git_root),
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else "Unknown error"
+        raise click.ClickException(f"Failed to create git worktree: {stderr}") from e
+
+    return worktree_dir, branch_name, False
+
+
+# =============================================================================
 # CLI Entry Point
 # =============================================================================
 
 
 @click.command()
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose logging")
+@click.option("-w", "--worktree", is_flag=True, default=False, help="Run in a git worktree.")
+@click.option(
+    "-b",
+    "--branch",
+    "worktree_branch",
+    default=None,
+    metavar="BRANCH",
+    help="Branch name for worktree (implies --worktree).",
+)
 @click.version_option(version=__version__, prog_name="paintress-cli")
-def cli(verbose: bool) -> None:
+def cli(verbose: bool, worktree: bool, worktree_branch: str | None) -> None:
     """Paintress CLI - AI-powered coding assistant.
 
     Inside TUI, use slash commands:
       /help     - Show available commands
       /config   - Show/edit configuration
       /mode     - Switch between act/plan modes
-      /dump     - Save session
-      /load     - Load session
+      /session  - List/restore sessions
+      /dump     - Save session to folder
+      /load     - Load session from folder
       /clear    - Clear conversation
       /exit     - Exit application
     """
@@ -483,12 +588,29 @@ def cli(verbose: bool) -> None:
     # Load env vars from config
     load_env_from_config(config)
 
+    # Set up worktree if requested
+    worktree_dir: Path | None = None
+    actual_branch: str | None = None
+    if worktree or worktree_branch is not None:
+        worktree_dir, actual_branch, is_resume = _create_worktree(worktree_branch)
+        if is_resume:
+            click.echo(click.style("Resuming worktree:", fg="cyan", bold=True))
+        else:
+            click.echo(click.style("Worktree created:", fg="cyan", bold=True))
+        click.echo(f"  Branch:    {actual_branch}")
+        click.echo(f"  Directory: {worktree_dir}")
+        click.echo()
+
+    working_dir = worktree_dir or Path.cwd()
+
     # Run the TUI
+    exit_code = 0
+    session_id: str | None = None
     try:
-        asyncio.run(_run_tui(config, config_manager, verbose))
+        session_id = asyncio.run(_run_tui(config, config_manager, verbose, working_dir=working_dir))
     except KeyboardInterrupt:
         click.echo("\nGoodbye!")
-        sys.exit(130)
+        exit_code = 130
     except Exception as e:
         logger.exception("Fatal error")
         click.echo()
@@ -514,19 +636,54 @@ def cli(verbose: bool) -> None:
         click.echo("  - Invalid model configuration")
         click.echo()
         click.echo(f"Check logs at: {LOG_FILE_NAME} (with --verbose flag)")
-        sys.exit(1)
+        exit_code = 1
+
+    # Show resume hints on exit
+    if session_id or worktree_dir is not None:
+        click.echo()
+
+    if session_id:
+        click.echo(click.style(f"Session: {session_id}", fg="cyan", bold=True))
+        click.echo()
+        click.echo("To resume this session:")
+        click.echo(f"  /session {session_id}")
+
+    if worktree_dir is not None:
+        click.echo()
+        click.echo(click.style("Worktree is still available:", fg="cyan", bold=True))
+        click.echo(f"  Directory: {worktree_dir}")
+        click.echo()
+        click.echo("To resume in this worktree:")
+        click.echo(f"  paintress-cli -w -b {actual_branch}")
+        click.echo()
+        click.echo("To remove when done:")
+        click.echo(f"  git worktree remove {worktree_dir}")
+
+    sys.exit(exit_code)
 
 
 async def _run_tui(
     config: PaintressConfig,
     config_manager: ConfigManager,
     verbose: bool,
-) -> None:
-    """Run the TUI application."""
+    *,
+    working_dir: Path | None = None,
+) -> str | None:
+    """Run the TUI application.
+
+    Returns:
+        Session ID if the session has saved data, None otherwise.
+    """
     from paintress_cli.app import TUIApp
 
-    async with TUIApp(config=config, config_manager=config_manager, verbose=verbose) as app:
+    async with TUIApp(
+        config=config,
+        config_manager=config_manager,
+        verbose=verbose,
+        working_dir=working_dir or Path.cwd(),
+    ) as app:
         await app.run()
+        return app.session_id if app.has_session_data else None
 
 
 def main() -> None:

--- a/paintress_cli/paintress_cli/cli.py
+++ b/paintress_cli/paintress_cli/cli.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 
 from paintress_cli import __version__  # pyright: ignore[reportAttributeAccessIssue]
-from paintress_cli.config import ConfigManager, WorktreeMetadata, PaintressConfig
+from paintress_cli.config import ConfigManager, PaintressConfig, WorktreeMetadata
 from paintress_cli.logging import LOG_FILE_NAME, configure_logging, get_logger
 
 logger = get_logger(__name__)

--- a/paintress_cli/paintress_cli/config.py
+++ b/paintress_cli/paintress_cli/config.py
@@ -23,11 +23,10 @@ Configuration files are loaded with project-level priority (no merging):
 
 from __future__ import annotations
 
-import hashlib
 import tomllib
 from importlib import resources
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -515,23 +514,32 @@ class ConfigManager:
         """Get path to project tools config file."""
         return self._project_dir / self.PROJECT_CONFIG_DIR / "tools.toml"
 
-    def get_project_hash(self) -> str:
-        """Generate stable hash from project directory path.
+    def get_sessions_dir(self) -> Path:
+        """Get sessions directory for session-based storage.
 
         Returns:
-            A 12-character hex string derived from SHA256 of the absolute project path.
+            Path to the sessions directory under global config.
+            Format: ~/.config/youware-labs/paintress-cli/sessions/
         """
-        path_str = str(self._project_dir.resolve())
-        return hashlib.sha256(path_str.encode()).hexdigest()[:12]
+        return self._config_dir / "sessions"
 
-    def get_auto_save_dir(self) -> Path:
-        """Get auto-save directory for current project.
 
-        Returns:
-            Path to the project-specific auto-save directory under global config.
-            Format: ~/.config/youware-labs/paintress-cli/message_history/{project_hash}/
-        """
-        return self._config_dir / "message_history" / self.get_project_hash()
+# =============================================================================
+# Worktree Metadata
+# =============================================================================
+
+
+class WorktreeMetadata(TypedDict):
+    """Metadata for a git worktree managed by paintress-cli.
+
+    Stored as JSON in ~/.config/youware-labs/paintress-cli/worktrees/{project_hash}/metadata.json.
+    """
+
+    git_root: str
+    """Absolute path to the original git repository root."""
+
+    created_at: str
+    """ISO 8601 timestamp of when this worktree group was first created."""
 
 
 # =============================================================================

--- a/paintress_cli/tests/test_app_integration.py
+++ b/paintress_cli/tests/test_app_integration.py
@@ -49,7 +49,7 @@ class MockConfigManager:
     global_config_dir: Any = field(default_factory=lambda: MagicMock())
     project_config_dir: Any = field(default_factory=lambda: MagicMock())
 
-    def get_auto_save_dir(self) -> Any:
+    def get_sessions_dir(self) -> Any:
         return MagicMock(exists=lambda: False)
 
     def get_mcp_config(self) -> None:

--- a/paintress_cli/tests/test_session.py
+++ b/paintress_cli/tests/test_session.py
@@ -1,0 +1,289 @@
+"""Tests for session management (save/load/prune/list)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from paintress_cli.config import ConfigManager
+
+# =============================================================================
+# ConfigManager.get_sessions_dir Tests
+# =============================================================================
+
+
+def test_get_sessions_dir(tmp_path: Path) -> None:
+    """Test get_sessions_dir returns correct path."""
+    config_dir = tmp_path / ".paintress_cli"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text('model = "anthropic:test"\n')
+
+    mgr = ConfigManager(config_dir=config_dir, project_dir=tmp_path)
+    sessions_dir = mgr.get_sessions_dir()
+
+    assert sessions_dir == config_dir / "sessions"
+
+
+# =============================================================================
+# Session ID Tests
+# =============================================================================
+
+
+def test_session_id_is_12_char_hex() -> None:
+    """Test that session_id is a 12-character hex string."""
+    from paintress_cli.app.tui import TUIApp
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = MagicMock(exists=lambda: False)
+
+    app = TUIApp(config=config, config_manager=config_manager)
+
+    assert len(app.session_id) == 12
+    assert re.match(r"^[0-9a-f]{12}$", app.session_id)
+
+
+def test_session_id_unique_per_instance() -> None:
+    """Test that each TUIApp instance gets a unique session_id."""
+    from paintress_cli.app.tui import TUIApp
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = MagicMock(exists=lambda: False)
+
+    app1 = TUIApp(config=config, config_manager=config_manager)
+    app2 = TUIApp(config=config, config_manager=config_manager)
+
+    assert app1.session_id != app2.session_id
+
+
+# =============================================================================
+# Prune Sessions Tests
+# =============================================================================
+
+
+def test_prune_sessions_no_op_under_limit(tmp_path: Path) -> None:
+    """Test prune does nothing when under limit."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    # Create 3 sessions
+    for i in range(3):
+        d = sessions_dir / f"session{i:04d}"
+        d.mkdir()
+        (d / "metadata.json").write_text(
+            json.dumps({
+                "session_id": f"session{i:04d}",
+                "updated_at": f"2026-01-{i + 1:02d}T00:00:00+00:00",
+            })
+        )
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+    app._prune_sessions(sessions_dir, max_sessions=5)
+
+    assert len(list(sessions_dir.iterdir())) == 3
+
+
+def test_prune_sessions_removes_oldest(tmp_path: Path) -> None:
+    """Test prune removes oldest sessions when over limit."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    # Create 5 sessions with different timestamps
+    for i in range(5):
+        d = sessions_dir / f"session{i:04d}"
+        d.mkdir()
+        (d / "metadata.json").write_text(
+            json.dumps({
+                "session_id": f"session{i:04d}",
+                "updated_at": f"2026-01-{i + 1:02d}T00:00:00+00:00",
+            })
+        )
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+    app._prune_sessions(sessions_dir, max_sessions=3)
+
+    remaining = sorted(d.name for d in sessions_dir.iterdir())
+    assert len(remaining) == 3
+    # Oldest (session0000, session0001) should be removed
+    assert remaining == ["session0002", "session0003", "session0004"]
+
+
+def test_prune_sessions_handles_missing_metadata(tmp_path: Path) -> None:
+    """Test prune handles sessions without metadata.json."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    # Create sessions - some with metadata, some without
+    for i in range(4):
+        d = sessions_dir / f"session{i:04d}"
+        d.mkdir()
+        if i >= 2:  # Only newer sessions have metadata
+            (d / "metadata.json").write_text(
+                json.dumps({
+                    "session_id": f"session{i:04d}",
+                    "updated_at": f"2026-02-{i + 1:02d}T00:00:00+00:00",
+                })
+            )
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+    app._prune_sessions(sessions_dir, max_sessions=2)
+
+    remaining = sorted(d.name for d in sessions_dir.iterdir())
+    assert len(remaining) == 2
+
+
+def test_prune_sessions_nonexistent_dir(tmp_path: Path) -> None:
+    """Test prune handles non-existent sessions directory."""
+    from paintress_cli.app.tui import TUIApp
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+
+    app = TUIApp(config=config, config_manager=config_manager)
+    # Should not raise
+    app._prune_sessions(tmp_path / "nonexistent")
+
+
+# =============================================================================
+# Load Session Tests
+# =============================================================================
+
+
+def test_load_session_exact_match(tmp_path: Path) -> None:
+    """Test loading session with exact ID match."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    session_dir = sessions_dir / "abc123def456"
+    session_dir.mkdir(parents=True)
+    (session_dir / "message_history.json").write_text("[]")
+    (session_dir / "context_state.json").write_text("{}")
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+    original_id = app.session_id
+
+    with patch.object(app, "_load_history") as mock_load:
+        app._load_session("abc123def456")
+
+    mock_load.assert_called_once_with(str(session_dir))
+    assert app.session_id == "abc123def456"
+    assert app.session_id != original_id
+
+
+def test_load_session_prefix_match(tmp_path: Path) -> None:
+    """Test loading session with prefix match."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    session_dir = sessions_dir / "abc123def456"
+    session_dir.mkdir(parents=True)
+    (session_dir / "message_history.json").write_text("[]")
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+
+    with patch.object(app, "_load_history") as mock_load:
+        app._load_session("abc1")
+
+    mock_load.assert_called_once_with(str(session_dir))
+    assert app.session_id == "abc123def456"
+
+
+def test_load_session_ambiguous(tmp_path: Path) -> None:
+    """Test loading session with ambiguous prefix."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    (sessions_dir / "abc123aaaaaa").mkdir(parents=True)
+    (sessions_dir / "abc123bbbbbb").mkdir(parents=True)
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+
+    with patch.object(app, "_append_system_output") as mock_output:
+        app._load_session("abc")
+
+    # Should mention "Ambiguous"
+    calls = [str(c) for c in mock_output.call_args_list]
+    assert any("Ambiguous" in c for c in calls)
+
+
+def test_load_session_not_found(tmp_path: Path) -> None:
+    """Test loading session that doesn't exist."""
+    from paintress_cli.app.tui import TUIApp
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    config = MagicMock()
+    config.general.max_requests = 10
+    config.display.max_output_lines = 500
+    config.display.mouse_support = True
+    config_manager = MagicMock()
+    config_manager.get_sessions_dir.return_value = sessions_dir
+
+    app = TUIApp(config=config, config_manager=config_manager)
+
+    with patch.object(app, "_append_system_output") as mock_output:
+        app._load_session("nonexistent")
+
+    calls = [str(c) for c in mock_output.call_args_list]
+    assert any("not found" in c for c in calls)

--- a/paintress_cli/tests/test_worktree.py
+++ b/paintress_cli/tests/test_worktree.py
@@ -1,0 +1,233 @@
+"""Tests for paintress_cli --worktree functionality."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from paintress_cli.cli import _create_worktree, _get_git_root, _project_hash, cli
+
+# =============================================================================
+# _get_git_root Tests
+# =============================================================================
+
+
+def test_get_git_root_in_repo(tmp_path: Path) -> None:
+    """Test _get_git_root returns root path inside a git repo."""
+    subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True, check=True)
+
+    # Get expected root
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=str(tmp_path),
+    )
+    expected = Path(result.stdout.strip())
+
+    # Capture real subprocess.run before patching
+    real_run = subprocess.run
+
+    def patched_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs.setdefault("cwd", str(tmp_path))
+        return real_run(*args, **kwargs)
+
+    with patch("paintress_cli.cli.subprocess.run", side_effect=patched_run):
+        root = _get_git_root()
+
+    assert root is not None
+    assert root == expected
+
+
+def test_get_git_root_not_in_repo(tmp_path: Path) -> None:
+    """Test _get_git_root returns None when not in a git repo."""
+    # Use a directory that's definitely not a git repo
+    with patch(
+        "paintress_cli.cli.subprocess.run",
+        side_effect=subprocess.CalledProcessError(128, "git"),
+    ):
+        root = _get_git_root()
+
+    assert root is None
+
+
+def test_get_git_root_git_not_installed() -> None:
+    """Test _get_git_root returns None when git is not installed."""
+    with patch("paintress_cli.cli.subprocess.run", side_effect=FileNotFoundError):
+        root = _get_git_root()
+
+    assert root is None
+
+
+# =============================================================================
+# _create_worktree Tests
+# =============================================================================
+
+
+def test_create_worktree_auto_branch(tmp_path: Path) -> None:
+    """Test _create_worktree with auto-generated branch name."""
+    # Create a git repo with an initial commit
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_dir = tmp_path / "config"
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True, check=True)
+    (repo / "README.md").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True)
+
+    with (
+        patch("paintress_cli.cli._get_git_root", return_value=repo),
+        patch("paintress_cli.cli.ConfigManager.DEFAULT_CONFIG_DIR", config_dir),
+    ):
+        worktree_dir, branch_name, is_resume = _create_worktree(None)
+
+    assert worktree_dir.exists()
+    assert not is_resume
+    assert branch_name.startswith("paintress/")
+    assert worktree_dir.parent == config_dir / "worktrees" / _project_hash(repo)
+
+    # Verify it's a valid git worktree
+    result = subprocess.run(
+        ["git", "worktree", "list"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert str(worktree_dir) in result.stdout
+
+    # Cleanup
+    subprocess.run(["git", "worktree", "remove", str(worktree_dir)], cwd=str(repo), capture_output=True, check=True)
+
+
+def test_create_worktree_custom_branch(tmp_path: Path) -> None:
+    """Test _create_worktree with a custom branch name."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_dir = tmp_path / "config"
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True, check=True)
+    (repo / "README.md").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True)
+
+    with (
+        patch("paintress_cli.cli._get_git_root", return_value=repo),
+        patch("paintress_cli.cli.ConfigManager.DEFAULT_CONFIG_DIR", config_dir),
+    ):
+        worktree_dir, branch_name, is_resume = _create_worktree("my-feature")
+
+    assert worktree_dir.exists()
+    assert not is_resume
+    assert branch_name == "my-feature"
+    assert worktree_dir.name == "my-feature"
+
+    # Verify metadata file was created with correct structure
+    metadata_file = worktree_dir.parent / "metadata.json"
+    assert metadata_file.exists()
+    metadata = json.loads(metadata_file.read_text())
+    assert metadata["git_root"] == str(repo.resolve())
+    assert "created_at" in metadata
+
+    # Cleanup
+    subprocess.run(["git", "worktree", "remove", str(worktree_dir)], cwd=str(repo), capture_output=True, check=True)
+
+
+def test_create_worktree_not_in_git_repo() -> None:
+    """Test _create_worktree raises error when not in a git repo."""
+    import click
+
+    with patch("paintress_cli.cli._get_git_root", return_value=None):
+        with pytest.raises(click.ClickException, match="requires a git repository"):
+            _create_worktree(None)
+
+
+def test_create_worktree_resume_existing(tmp_path: Path) -> None:
+    """Test _create_worktree resumes when worktree dir already exists."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_dir = tmp_path / "config"
+
+    # Pre-create the worktree directory (simulating a previous run)
+    proj_hash = _project_hash(repo)
+    worktrees_base = config_dir / "worktrees" / proj_hash
+    worktrees_base.mkdir(parents=True)
+    existing = worktrees_base / "my-branch"
+    existing.mkdir()
+
+    with (
+        patch("paintress_cli.cli._get_git_root", return_value=repo),
+        patch("paintress_cli.cli.ConfigManager.DEFAULT_CONFIG_DIR", config_dir),
+    ):
+        worktree_dir, branch_name, is_resume = _create_worktree("my-branch")
+
+    assert worktree_dir == existing
+    assert branch_name == "my-branch"
+    assert is_resume
+
+
+def test_create_worktree_git_failure(tmp_path: Path) -> None:
+    """Test _create_worktree raises error when git command fails."""
+    import click
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    error = subprocess.CalledProcessError(128, "git", stderr="fatal: invalid reference: HEAD")
+
+    with (
+        patch("paintress_cli.cli._get_git_root", return_value=repo),
+        patch("paintress_cli.cli.subprocess.run", side_effect=error),
+    ):
+        with pytest.raises(click.ClickException, match="Failed to create git worktree"):
+            _create_worktree("test-branch")
+
+
+# =============================================================================
+# CLI --worktree Option Tests
+# =============================================================================
+
+
+def test_cli_worktree_option_exists() -> None:
+    """Test that --worktree and --branch options are recognized by the CLI."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "--worktree" in result.output
+    assert "--branch" in result.output
+
+
+def test_cli_worktree_not_in_repo(tmp_path: Path) -> None:
+    """Test CLI exits with error when --worktree used outside git repo."""
+    runner = CliRunner()
+    with (
+        patch("paintress_cli.cli._get_git_root", return_value=None),
+        patch("paintress_cli.cli.ConfigManager.load", return_value=MagicMock(is_configured=True, env={})),
+        patch("paintress_cli.cli.ensure_builtin_assets"),
+        patch("paintress_cli.cli.load_env_from_config"),
+    ):
+        result = runner.invoke(cli, ["--worktree"])
+    assert result.exit_code != 0
+    assert "requires a git repository" in result.output
+
+
+def test_cli_branch_implies_worktree(tmp_path: Path) -> None:
+    """Test --branch implies --worktree."""
+    runner = CliRunner()
+    with (
+        patch("paintress_cli.cli._get_git_root", return_value=None),
+        patch("paintress_cli.cli.ConfigManager.load", return_value=MagicMock(is_configured=True, env={})),
+        patch("paintress_cli.cli.ensure_builtin_assets"),
+        patch("paintress_cli.cli.load_env_from_config"),
+    ):
+        result = runner.invoke(cli, ["--branch", "my-feature"])
+    assert result.exit_code != 0
+    assert "requires a git repository" in result.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,8 +157,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "paintress_cli/paintress_cli/*" = ["C901", "SIM108"]
-"paintress_cli/tests/*" = ["S101", "SIM117", "RUF059", "TRY400", "B904"]
-"tests/*" = ["S101", "SIM117", "RUF059", "TRY400", "B904"]
+"paintress_cli/tests/*" = ["S101", "S603", "S607", "SIM117", "RUF059", "TRY400", "B904"]
+"tests/*" = ["S101", "S603", "S607", "SIM117", "RUF059", "TRY400", "B904"]
 "skills/examples/*" = ["S101", "SIM117", "RUF059", "TRY400", "B904", "E402"]
 "examples/*" = ["S101", "SIM117", "RUF059", "TRY400", "B904", "E402"]
 


### PR DESCRIPTION
- Add --worktree / --branch options for isolated agent work in git worktrees
- Replace project-hash auto-save with per-session storage (sessions/)
- Add /session command to list and restore sessions by ID (prefix match)
- Auto-prune old sessions beyond retention limit (default: 100)
- Show session ID and worktree resume hints on exit