### PR TITLE
feat(presets): add Anthropic interleaved thinking presets

### DIFF
--- a/pai_agent_sdk/presets.py
+++ b/pai_agent_sdk/presets.py
@@ -82,12 +82,26 @@ class ModelSettingsPreset(str, Enum):
     ANTHROPIC_LOW = "anthropic_low"
     ANTHROPIC_OFF = "anthropic_off"
 
+    # Anthropic interleaved thinking presets (with beta headers)
+    ANTHROPIC_DEFAULT_INTERLEAVED_THINKING = "anthropic_default_interleaved_thinking"
+    ANTHROPIC_HIGH_INTERLEAVED_THINKING = "anthropic_high_interleaved_thinking"
+    ANTHROPIC_MEDIUM_INTERLEAVED_THINKING = "anthropic_medium_interleaved_thinking"
+    ANTHROPIC_LOW_INTERLEAVED_THINKING = "anthropic_low_interleaved_thinking"
+    ANTHROPIC_OFF_INTERLEAVED_THINKING = "anthropic_off_interleaved_thinking"
+
     # Anthropic 1M context presets (with beta headers for extended context)
     ANTHROPIC_1M_DEFAULT = "anthropic_1m_default"
     ANTHROPIC_1M_HIGH = "anthropic_1m_high"
     ANTHROPIC_1M_MEDIUM = "anthropic_1m_medium"
     ANTHROPIC_1M_LOW = "anthropic_1m_low"
     ANTHROPIC_1M_OFF = "anthropic_1m_off"
+
+    # Anthropic 1M context + interleaved thinking presets (with beta headers)
+    ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING = "anthropic_1m_default_interleaved_thinking"
+    ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING = "anthropic_1m_high_interleaved_thinking"
+    ANTHROPIC_1M_MEDIUM_INTERLEAVED_THINKING = "anthropic_1m_medium_interleaved_thinking"
+    ANTHROPIC_1M_LOW_INTERLEAVED_THINKING = "anthropic_1m_low_interleaved_thinking"
+    ANTHROPIC_1M_OFF_INTERLEAVED_THINKING = "anthropic_1m_off_interleaved_thinking"
 
     # OpenAI Chat Completions presets (GPT-4, etc.)
     OPENAI_DEFAULT = "openai_default"
@@ -125,6 +139,7 @@ def _anthropic_settings(
     max_tokens: int = 21 * K_TOKENS,
     *,
     use_1m_context: bool = False,
+    use_interleaved_thinking: bool = False,
 ) -> dict[str, Any]:
     """Create Anthropic model settings with thinking enabled.
 
@@ -132,6 +147,7 @@ def _anthropic_settings(
         thinking_budget: Token budget for thinking (higher = more reasoning).
         max_tokens: Maximum output tokens.
         use_1m_context: Whether to include 1M context beta headers.
+        use_interleaved_thinking: Whether to include interleaved thinking beta headers.
 
     Returns:
         Dict suitable for AnthropicModelSettings.
@@ -146,16 +162,21 @@ def _anthropic_settings(
         "anthropic_cache_response": True,
         "anthropic_cache_messages": True,
     }
-    if use_1m_context:
-        settings["extra_headers"] = build_anthropic_betas(use_1m_context=use_1m_context, use_interleaved_thinking=True)
+    extra_headers = build_anthropic_betas(
+        use_1m_context=use_1m_context,
+        use_interleaved_thinking=use_interleaved_thinking,
+    )
+    if extra_headers:
+        settings["extra_headers"] = extra_headers
     return settings
 
 
-def _anthropic_off_settings(*, use_1m_context: bool = False) -> dict[str, Any]:
+def _anthropic_off_settings(*, use_1m_context: bool = False, use_interleaved_thinking: bool = False) -> dict[str, Any]:
     """Create Anthropic model settings with thinking disabled.
 
     Args:
         use_1m_context: Whether to include 1M context beta headers.
+        use_interleaved_thinking: Whether to include interleaved thinking beta headers.
 
     Returns:
         Dict suitable for AnthropicModelSettings.
@@ -168,8 +189,12 @@ def _anthropic_off_settings(*, use_1m_context: bool = False) -> dict[str, Any]:
         "anthropic_cache_response": True,
         "anthropic_cache_messages": True,
     }
-    if use_1m_context:
-        settings["extra_headers"] = build_anthropic_betas(use_1m_context=use_1m_context)
+    extra_headers = build_anthropic_betas(
+        use_1m_context=use_1m_context,
+        use_interleaved_thinking=use_interleaved_thinking,
+    )
+    if extra_headers:
+        settings["extra_headers"] = extra_headers
     return settings
 
 
@@ -205,6 +230,43 @@ ANTHROPIC_OFF: dict[str, Any] = _anthropic_off_settings()
 """Anthropic off: Thinking disabled, caching enabled."""
 
 # -----------------------------------------------------------------------------
+# Anthropic interleaved thinking presets (with beta headers)
+# -----------------------------------------------------------------------------
+
+ANTHROPIC_DEFAULT_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=16 * K_TOKENS,
+    max_tokens=21 * K_TOKENS,
+    use_interleaved_thinking=True,
+)
+"""Anthropic interleaved default: Same as medium with interleaved thinking beta."""
+
+ANTHROPIC_HIGH_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=32 * K_TOKENS,
+    max_tokens=21 * K_TOKENS,
+    use_interleaved_thinking=True,
+)
+"""Anthropic interleaved high: 32K thinking budget with interleaved thinking beta."""
+
+ANTHROPIC_MEDIUM_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=16 * K_TOKENS,
+    max_tokens=21 * K_TOKENS,
+    use_interleaved_thinking=True,
+)
+"""Anthropic interleaved medium: 16K thinking budget with interleaved thinking beta."""
+
+ANTHROPIC_LOW_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=4 * K_TOKENS,
+    max_tokens=8 * K_TOKENS,
+    use_interleaved_thinking=True,
+)
+"""Anthropic interleaved low: 4K thinking budget with interleaved thinking beta."""
+
+ANTHROPIC_OFF_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_off_settings(
+    use_interleaved_thinking=True,
+)
+"""Anthropic interleaved off: Thinking disabled with interleaved thinking beta and caching enabled."""
+
+# -----------------------------------------------------------------------------
 # Anthropic 1M context presets (with beta headers for extended context)
 # -----------------------------------------------------------------------------
 
@@ -238,6 +300,48 @@ ANTHROPIC_1M_LOW: dict[str, Any] = _anthropic_settings(
 
 ANTHROPIC_1M_OFF: dict[str, Any] = _anthropic_off_settings(use_1m_context=True)
 """Anthropic 1M off: Thinking disabled, with 1M context beta and caching enabled."""
+
+# -----------------------------------------------------------------------------
+# Anthropic 1M context + interleaved thinking presets (with beta headers)
+# -----------------------------------------------------------------------------
+
+ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=16 * K_TOKENS,
+    max_tokens=16 * K_TOKENS,
+    use_1m_context=True,
+    use_interleaved_thinking=True,
+)
+"""Anthropic 1M interleaved default: 16K thinking budget with 1M + interleaved betas."""
+
+ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=32 * K_TOKENS,
+    max_tokens=21 * K_TOKENS,
+    use_1m_context=True,
+    use_interleaved_thinking=True,
+)
+"""Anthropic 1M interleaved high: 32K thinking budget with 1M + interleaved betas."""
+
+ANTHROPIC_1M_MEDIUM_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=16 * K_TOKENS,
+    max_tokens=16 * K_TOKENS,
+    use_1m_context=True,
+    use_interleaved_thinking=True,
+)
+"""Anthropic 1M interleaved medium: 16K thinking budget with 1M + interleaved betas."""
+
+ANTHROPIC_1M_LOW_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_settings(
+    thinking_budget=4 * K_TOKENS,
+    max_tokens=8 * K_TOKENS,
+    use_1m_context=True,
+    use_interleaved_thinking=True,
+)
+"""Anthropic 1M interleaved low: 4K thinking budget with 1M + interleaved betas."""
+
+ANTHROPIC_1M_OFF_INTERLEAVED_THINKING: dict[str, Any] = _anthropic_off_settings(
+    use_1m_context=True,
+    use_interleaved_thinking=True,
+)
+"""Anthropic 1M interleaved off: Thinking disabled with 1M + interleaved betas and caching enabled."""
 
 
 # =============================================================================
@@ -490,12 +594,24 @@ _PRESET_REGISTRY: dict[str, dict[str, Any]] = {
     ModelSettingsPreset.ANTHROPIC_MEDIUM.value: ANTHROPIC_MEDIUM,
     ModelSettingsPreset.ANTHROPIC_LOW.value: ANTHROPIC_LOW,
     ModelSettingsPreset.ANTHROPIC_OFF.value: ANTHROPIC_OFF,
+    # Anthropic interleaved thinking (with beta headers)
+    ModelSettingsPreset.ANTHROPIC_DEFAULT_INTERLEAVED_THINKING.value: ANTHROPIC_DEFAULT_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_HIGH_INTERLEAVED_THINKING.value: ANTHROPIC_HIGH_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_MEDIUM_INTERLEAVED_THINKING.value: ANTHROPIC_MEDIUM_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_LOW_INTERLEAVED_THINKING.value: ANTHROPIC_LOW_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_OFF_INTERLEAVED_THINKING.value: ANTHROPIC_OFF_INTERLEAVED_THINKING,
     # Anthropic 1M context (with beta headers)
     ModelSettingsPreset.ANTHROPIC_1M_DEFAULT.value: ANTHROPIC_1M_DEFAULT,
     ModelSettingsPreset.ANTHROPIC_1M_HIGH.value: ANTHROPIC_1M_HIGH,
     ModelSettingsPreset.ANTHROPIC_1M_MEDIUM.value: ANTHROPIC_1M_MEDIUM,
     ModelSettingsPreset.ANTHROPIC_1M_LOW.value: ANTHROPIC_1M_LOW,
     ModelSettingsPreset.ANTHROPIC_1M_OFF.value: ANTHROPIC_1M_OFF,
+    # Anthropic 1M context + interleaved thinking (with beta headers)
+    ModelSettingsPreset.ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING.value: ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING.value: ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_1M_MEDIUM_INTERLEAVED_THINKING.value: ANTHROPIC_1M_MEDIUM_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_1M_LOW_INTERLEAVED_THINKING.value: ANTHROPIC_1M_LOW_INTERLEAVED_THINKING,
+    ModelSettingsPreset.ANTHROPIC_1M_OFF_INTERLEAVED_THINKING.value: ANTHROPIC_1M_OFF_INTERLEAVED_THINKING,
     # OpenAI Chat
     ModelSettingsPreset.OPENAI_DEFAULT.value: OPENAI_DEFAULT,
     ModelSettingsPreset.OPENAI_HIGH.value: OPENAI_HIGH,
@@ -523,7 +639,9 @@ _PRESET_REGISTRY: dict[str, dict[str, Any]] = {
 _PRESET_ALIASES: dict[str, str] = {
     # Provider defaults (default preset)
     "anthropic": ModelSettingsPreset.ANTHROPIC_DEFAULT.value,
+    "anthropic_interleaved": ModelSettingsPreset.ANTHROPIC_DEFAULT_INTERLEAVED_THINKING.value,
     "anthropic_1m": ModelSettingsPreset.ANTHROPIC_1M_DEFAULT.value,
+    "anthropic_1m_interleaved": ModelSettingsPreset.ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING.value,
     "openai": ModelSettingsPreset.OPENAI_DEFAULT.value,
     "openai_responses": ModelSettingsPreset.OPENAI_RESPONSES_DEFAULT.value,
     "gemini_2.5": ModelSettingsPreset.GEMINI_THINKING_BUDGET_DEFAULT.value,

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -7,15 +7,25 @@ from inline_snapshot import snapshot
 
 from pai_agent_sdk.presets import (
     ANTHROPIC_1M_DEFAULT,
+    ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING,
     ANTHROPIC_1M_HIGH,
+    ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING,
     ANTHROPIC_1M_LOW,
+    ANTHROPIC_1M_LOW_INTERLEAVED_THINKING,
     ANTHROPIC_1M_MEDIUM,
+    ANTHROPIC_1M_MEDIUM_INTERLEAVED_THINKING,
     ANTHROPIC_1M_OFF,
+    ANTHROPIC_1M_OFF_INTERLEAVED_THINKING,
     ANTHROPIC_DEFAULT,
+    ANTHROPIC_DEFAULT_INTERLEAVED_THINKING,
     ANTHROPIC_HIGH,
+    ANTHROPIC_HIGH_INTERLEAVED_THINKING,
     ANTHROPIC_LOW,
+    ANTHROPIC_LOW_INTERLEAVED_THINKING,
     ANTHROPIC_MEDIUM,
+    ANTHROPIC_MEDIUM_INTERLEAVED_THINKING,
     ANTHROPIC_OFF,
+    ANTHROPIC_OFF_INTERLEAVED_THINKING,
     INHERIT,
     OPENAI_DEFAULT,
     OPENAI_HIGH,
@@ -81,6 +91,50 @@ def test_anthropic_1m_presets_structure() -> None:
     assert "anthropic-beta" in ANTHROPIC_1M_OFF["extra_headers"]
 
 
+def test_anthropic_interleaved_presets_structure() -> None:
+    """Test that Anthropic interleaved presets have interleaved beta header and caching."""
+    for preset in [
+        ANTHROPIC_DEFAULT_INTERLEAVED_THINKING,
+        ANTHROPIC_HIGH_INTERLEAVED_THINKING,
+        ANTHROPIC_MEDIUM_INTERLEAVED_THINKING,
+        ANTHROPIC_LOW_INTERLEAVED_THINKING,
+    ]:
+        assert "extra_headers" in preset
+        assert "anthropic-beta" in preset["extra_headers"]
+        assert "interleaved-thinking" in preset["extra_headers"]["anthropic-beta"]
+        assert preset["anthropic_cache_instructions"] is True
+        assert preset["anthropic_cache_messages"] is True
+
+    # OFF should disable thinking but still include interleaved beta header
+    assert ANTHROPIC_OFF_INTERLEAVED_THINKING["anthropic_thinking"]["type"] == "disabled"
+    assert "extra_headers" in ANTHROPIC_OFF_INTERLEAVED_THINKING
+    assert "anthropic-beta" in ANTHROPIC_OFF_INTERLEAVED_THINKING["extra_headers"]
+    assert "interleaved-thinking" in ANTHROPIC_OFF_INTERLEAVED_THINKING["extra_headers"]["anthropic-beta"]
+
+
+def test_anthropic_1m_interleaved_presets_structure() -> None:
+    """Test that Anthropic 1M interleaved presets include both beta headers and caching."""
+    for preset in [
+        ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING,
+        ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING,
+        ANTHROPIC_1M_MEDIUM_INTERLEAVED_THINKING,
+        ANTHROPIC_1M_LOW_INTERLEAVED_THINKING,
+    ]:
+        assert "extra_headers" in preset
+        assert "anthropic-beta" in preset["extra_headers"]
+        assert "context-1m" in preset["extra_headers"]["anthropic-beta"]
+        assert "interleaved-thinking" in preset["extra_headers"]["anthropic-beta"]
+        assert preset["anthropic_cache_instructions"] is True
+        assert preset["anthropic_cache_messages"] is True
+
+    # OFF should disable thinking but still include both beta headers
+    assert ANTHROPIC_1M_OFF_INTERLEAVED_THINKING["anthropic_thinking"]["type"] == "disabled"
+    assert "extra_headers" in ANTHROPIC_1M_OFF_INTERLEAVED_THINKING
+    assert "anthropic-beta" in ANTHROPIC_1M_OFF_INTERLEAVED_THINKING["extra_headers"]
+    assert "context-1m" in ANTHROPIC_1M_OFF_INTERLEAVED_THINKING["extra_headers"]["anthropic-beta"]
+    assert "interleaved-thinking" in ANTHROPIC_1M_OFF_INTERLEAVED_THINKING["extra_headers"]["anthropic-beta"]
+
+
 def test_anthropic_thinking_budgets() -> None:
     """Test that Anthropic thinking budgets are ordered correctly."""
     # Standard presets
@@ -129,6 +183,12 @@ def test_get_model_settings_by_enum() -> None:
     settings_1m = get_model_settings(ModelSettingsPreset.ANTHROPIC_1M_HIGH)
     assert settings_1m == ANTHROPIC_1M_HIGH
 
+    settings_interleaved = get_model_settings(ModelSettingsPreset.ANTHROPIC_HIGH_INTERLEAVED_THINKING)
+    assert settings_interleaved == ANTHROPIC_HIGH_INTERLEAVED_THINKING
+
+    settings_1m_interleaved = get_model_settings(ModelSettingsPreset.ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING)
+    assert settings_1m_interleaved == ANTHROPIC_1M_HIGH_INTERLEAVED_THINKING
+
 
 def test_get_model_settings_by_string() -> None:
     """Test getting model settings by string name."""
@@ -148,6 +208,12 @@ def test_get_model_settings_by_alias() -> None:
     # Test 1M alias
     settings_1m = get_model_settings("anthropic_1m")
     assert settings_1m == ANTHROPIC_1M_DEFAULT
+
+    settings_interleaved = get_model_settings("anthropic_interleaved")
+    assert settings_interleaved == ANTHROPIC_DEFAULT_INTERLEAVED_THINKING
+
+    settings_1m_interleaved = get_model_settings("anthropic_1m_interleaved")
+    assert settings_1m_interleaved == ANTHROPIC_1M_DEFAULT_INTERLEAVED_THINKING
 
     settings = get_model_settings("openai")
     assert settings == OPENAI_DEFAULT
@@ -190,15 +256,27 @@ def test_list_presets() -> None:
         "anthropic",
         "anthropic_1m",
         "anthropic_1m_default",
+        "anthropic_1m_default_interleaved_thinking",
         "anthropic_1m_high",
+        "anthropic_1m_high_interleaved_thinking",
+        "anthropic_1m_interleaved",
         "anthropic_1m_low",
+        "anthropic_1m_low_interleaved_thinking",
         "anthropic_1m_medium",
+        "anthropic_1m_medium_interleaved_thinking",
         "anthropic_1m_off",
+        "anthropic_1m_off_interleaved_thinking",
         "anthropic_default",
+        "anthropic_default_interleaved_thinking",
         "anthropic_high",
+        "anthropic_high_interleaved_thinking",
+        "anthropic_interleaved",
         "anthropic_low",
+        "anthropic_low_interleaved_thinking",
         "anthropic_medium",
+        "anthropic_medium_interleaved_thinking",
         "anthropic_off",
+        "anthropic_off_interleaved_thinking",
         "gemini",
         "gemini_2.5",
         "gemini_3",


### PR DESCRIPTION
Add interleaved thinking model settings presets for Anthropic, covering both standard and 1M context variants (default/high/medium/low/off).

- Add `use_interleaved_thinking` parameter to `_anthropic_settings` and `_anthropic_off_settings` for beta header injection
- Refactor beta header logic to build and apply conditionally
- Register new presets in enum, registry, and aliases (`anthropic_interleaved`, `anthropic_1m_interleaved`)
- Add tests for interleaved and 1M interleaved preset structure